### PR TITLE
Added API for Chemical Injection Chamber

### DIFF
--- a/src/main/java/mekanism/api/gas/GasifyableItems.java
+++ b/src/main/java/mekanism/api/gas/GasifyableItems.java
@@ -1,0 +1,41 @@
+package mekanism.api.gas;
+
+import mekanism.common.util.MekanismUtils;
+import net.minecraft.item.ItemStack;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+public class GasifyableItems {
+
+    static HashMap<String, GasStack> gasifyableItems = new HashMap<String, GasStack>();
+    static List<Gas> validGases = new ArrayList<>();
+
+    public static void registerGasifyables(String oredict, Gas gas, Integer quantity) {
+        System.out.println("oredict = " + oredict);
+        System.out.println("gas = " + gas);
+        System.out.println("quantity = " + quantity);
+
+        GasStack gasifyEntry = new GasStack(gas, quantity);
+
+        gasifyableItems.put(oredict, gasifyEntry);
+        validGases.add(gas);
+    }
+
+    public static GasStack getGasFromItem(ItemStack itemstack) {
+
+        List<String> oredict = MekanismUtils.getOreDictName(itemstack);
+
+        for (String s : oredict) {
+            if (gasifyableItems.containsKey(s))
+                return gasifyableItems.get(s);
+        }
+        return null;
+    }
+
+    public static boolean isGasValidGasifyable(Gas gas) {
+        return validGases.contains(gas);
+    }
+}

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -18,11 +18,8 @@ import mekanism.api.MekanismAPI.BoxBlacklistEvent;
 import mekanism.api.MekanismConfig;
 import mekanism.api.MekanismConfig.general;
 import mekanism.api.MekanismConfig.usage;
-import mekanism.api.gas.Gas;
+import mekanism.api.gas.*;
 import mekanism.api.gas.GasNetwork.GasTransferEvent;
-import mekanism.api.gas.GasRegistry;
-import mekanism.api.gas.GasStack;
-import mekanism.api.gas.OreGas;
 import mekanism.api.infuse.InfuseObject;
 import mekanism.api.infuse.InfuseRegistry;
 import mekanism.api.infuse.InfuseType;
@@ -1440,13 +1437,18 @@ public class Mekanism
 		FluidRegistry.registerFluid(new Fluid("heavyWater"));
 		FluidRegistry.registerFluid(new Fluid("steam").setGaseous(true));
 
-		for(Resource resource : Resource.values())
-		{
+		for(Resource resource : Resource.values()) {
 			String name = resource.getName();
 
-			OreGas clean = (OreGas)GasRegistry.register(new OreGas("clean" + name, "oregas." + name.toLowerCase()).setVisible(false));
+			OreGas clean = (OreGas) GasRegistry.register(new OreGas("clean" + name, "oregas." + name.toLowerCase()).setVisible(false));
 			GasRegistry.register(new OreGas(name.toLowerCase(), "oregas." + name.toLowerCase()).setCleanGas(clean).setVisible(false));
 		}
+
+		//Register Gasifyable Items
+		GasifyableItems.registerGasifyables("dustSulfur", GasRegistry.getGas("sulfuricAcid"), 2);
+		GasifyableItems.registerGasifyables("dustSalt", GasRegistry.getGas("hydrogenChloride"), 2);
+		GasifyableItems.registerGasifyables("dustSugar", GasRegistry.getGas("molasse"), 90);
+		GasifyableItems.registerGasifyables("listAllSugar", GasRegistry.getGas("molasse"), 90);
 
 		Mekanism.proxy.preInit();
 

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalInjectionChamber.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalInjectionChamber.java
@@ -4,11 +4,7 @@ import java.util.Map;
 
 import mekanism.api.EnumColor;
 import mekanism.api.MekanismConfig.usage;
-import mekanism.api.gas.Gas;
-import mekanism.api.gas.GasRegistry;
-import mekanism.api.gas.GasStack;
-import mekanism.api.gas.GasTransmission;
-import mekanism.api.gas.IGasItem;
+import mekanism.api.gas.*;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.MekanismBlocks;
 import mekanism.common.SideData;
@@ -43,9 +39,11 @@ public class TileEntityChemicalInjectionChamber extends TileEntityAdvancedElectr
 	@Override
 	public GasStack getItemGas(ItemStack itemstack)
 	{
-		if(MekanismUtils.getOreDictName(itemstack).contains("dustSulfur")) return new GasStack(GasRegistry.getGas("sulfuricAcid"), 2);
-		if(MekanismUtils.getOreDictName(itemstack).contains("dustSalt")) return new GasStack(GasRegistry.getGas("hydrogenChloride"), 2);
-		if(MekanismUtils.getOreDictName(itemstack).contains("dustSugar") || MekanismUtils.getOreDictName(itemstack).contains("listAllSugar")) return new GasStack(GasRegistry.getGas("molasse"), 90);
+		if (GasifyableItems.getGasFromItem(itemstack) != null) {
+			System.out.println(GasifyableItems.getGasFromItem(itemstack).getGas().getUnlocalizedName());
+			return GasifyableItems.getGasFromItem(itemstack);
+		}
+		else
 		if(Block.getBlockFromItem(itemstack.getItem()) == MekanismBlocks.GasTank && ((IGasItem)itemstack.getItem()).getGas(itemstack) != null &&
 				isValidGas(((IGasItem)itemstack.getItem()).getGas(itemstack).getGas())) return new GasStack(GasRegistry.getGas("sulfuricAcid"), 1);
 
@@ -102,7 +100,7 @@ public class TileEntityChemicalInjectionChamber extends TileEntityAdvancedElectr
 	@Override
 	public boolean isValidGas(Gas gas)
 	{
-		return gas == GasRegistry.getGas("sulfuricAcid") || gas == GasRegistry.getGas("water") || gas == GasRegistry.getGas("hydrogenChloride")|| gas == GasRegistry.getGas("molasse");
+		return (gas == GasRegistry.getGas("water") || GasifyableItems.isGasValidGasifyable(gas));
 	}
 
 	@Override


### PR DESCRIPTION
## Changes proposed in this pull request:
Adds API for the Chemical Injection Chamber.

Usable gases are no longer hardcoded and can be added with:

`GasifyableItems.registerGasifyables("<OredictionaryEntry>", GasRegistry.getGas("<GasName>"), <quantity>);`

This allows for both Mekanism and other mods to modify the valid gases it can accept as well as items to gasify for their own recipes.