### PR TITLE
Two fixes[1.12.2]

### DIFF
--- a/src/main/java/mekanism/common/inventory/container/ContainerPersonalChest.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerPersonalChest.java
@@ -1,8 +1,9 @@
 package mekanism.common.inventory.container;
 
 import invtweaks.api.container.ChestContainer;
-import javax.annotation.Nonnull;
+import mekanism.common.block.states.BlockStateMachine;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
+import mekanism.common.inventory.InventoryPersonalChest;
 import mekanism.common.inventory.slot.SlotPersonalChest;
 import mekanism.common.tile.TileEntityPersonalChest;
 import net.minecraft.entity.player.EntityPlayer;
@@ -11,6 +12,9 @@ import net.minecraft.inventory.ClickType;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @ChestContainer(isLargeChest = true)
 public class ContainerPersonalChest extends ContainerMekanism<TileEntityPersonalChest> {
@@ -85,12 +89,18 @@ public class ContainerPersonalChest extends ContainerMekanism<TileEntityPersonal
         return itemInventory;
     }
 
+    @ParametersAreNonnullByDefault
     @Override
     public boolean canInteractWith(@Nonnull EntityPlayer entityplayer) {
         if (isBlock) {
-            return tileEntity.isUsableByPlayer(entityplayer);
+            return super.canInteractWith(entityplayer);
         }
-        return true;
+        final ItemStack currentItem = entityplayer.getHeldItemMainhand();
+        if (itemInventory instanceof InventoryPersonalChest) {
+            final ItemStack stack = ((InventoryPersonalChest) itemInventory).getStack();
+            return super.canInteractWith(entityplayer) && !stack.isEmpty() && currentItem == stack && BlockStateMachine.MachineType.get(stack) == BlockStateMachine.MachineType.PERSONAL_CHEST;
+        }
+        return false;
     }
 
     @Nonnull

--- a/src/main/resources/assets/mekanism/lang/zh_cn.lang
+++ b/src/main/resources/assets/mekanism/lang/zh_cn.lang
@@ -100,7 +100,7 @@ tile.BasicBlock.DynamicValve.name=动态阀门
 tile.BasicBlock.CopperBlock.name=铜块
 tile.BasicBlock.TinBlock.name=锡块
 tile.BasicBlock.ThermalEvaporationController.name=热力蒸馏控制器
-tile.BasicBlock.ThermalEvaporationValve.name==热力蒸馏阀门
+tile.BasicBlock.ThermalEvaporationValve.name=热力蒸馏阀门
 
 # Basic Block 2 (second ID iteration)
 tile.BasicBlock2.ThermalEvaporationBlock.name=热力蒸馏方块
@@ -608,6 +608,7 @@ gui.factory.Combining=融合
 gui.factory.Purifying=提纯
 gui.factory.Injecting=压射
 gui.factory.Infusing=灌注
+gui.factory.Sawing=切割
 
 gui.seismicReader.short=地震读取器
 gui.seismicReader.solids=固体


### PR DESCRIPTION
1. Fix missing and duplicate entries in zh_cn
2. Fixed a bug where Personal Chest could switch inventory to copy with it open [[Through code in the DupeFix Project](https://github.com/focamacho/DupeFix-Project/blob/ba7cce628bfa509179de0c30cb42d63ca87b4efe/src/main/java/com/focamacho/dupefixproject/mixin/mekanism/ContainerPersonalChestMixin.java#L30-L39)] #130 