### PR TITLE
Plat Compat Shenanigans

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ FMP_version=1.2.0.345
 CCLIB_version=1.1.3.141
 NEI_version=1.0.5.120
 CCC_version=1.0.7.48
-mod_version=9.10.31
-alt_version=9, 10, 31
+mod_version=9.10.32
+alt_version=9, 10, 32

--- a/src/main/java/mekanism/client/render/MekanismRenderer.java
+++ b/src/main/java/mekanism/client/render/MekanismRenderer.java
@@ -100,7 +100,8 @@ public class MekanismRenderer
 			GasRegistry.getGas("sulfurTrioxideGas").setIcon(event.map.registerIcon("mekanism:liquid/LiquidSulfurTrioxide"));
 			GasRegistry.getGas("sulfuricAcid").setIcon(event.map.registerIcon("mekanism:liquid/LiquidSulfuricAcid"));
 			GasRegistry.getGas("hydrogenChloride").setIcon(event.map.registerIcon("mekanism:liquid/LiquidHydrogenChloride"));
-			GasRegistry.getGas("liquid" + Resource.OSMIUM.getName()).setIcon(event.map.registerIcon("mekanism:liquid/LiquidOsmium"));
+			GasRegistry.getGas("liquidOsmium").setIcon(event.map.registerIcon("mekanism:liquid/LiquidOsmium"));
+			GasRegistry.getGas("liquidPlatinum").setIcon(event.map.registerIcon("mekanism:liquid/LiquidOsmium"));
 			GasRegistry.getGas("liquidStone").setIcon(event.map.registerIcon("mekanism:liquid/LiquidStone"));
 			GasRegistry.getGas("ethene").setIcon(event.map.registerIcon("mekanism:liquid/LiquidEthene"));
 			GasRegistry.getGas("brine").setIcon(event.map.registerIcon("mekanism:liquid/LiquidBrine"));

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -1380,7 +1380,11 @@ public class Mekanism
 		configurationrecipes = new Configuration(new File("config/mekanism/MekanismRecipes.cfg"));
 		configurationce = new Configuration(new File("config/mekanism/MekanismCE.cfg"));
 
-        //Register tier information
+		//Load configuration
+		proxy.loadConfiguration();
+		proxy.onConfigSync(false);
+
+		//Register tier information
         Tier.init();
 
 		GasRegistry.register(new Gas("hydrogen")).registerFluid();
@@ -1474,10 +1478,6 @@ public class Mekanism
 
 		//Register with TransmitterNetworkRegistry
 		TransmitterNetworkRegistry.initiate();
-
-		//Load configuration
-		proxy.loadConfiguration();
-		proxy.onConfigSync(false);
 
 		//Add baby skeleton spawner
 		if(general.spawnBabySkeletons)

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -212,11 +212,14 @@ public class Mekanism
 
 	public static Set<Coord4D> activeVibrators = new HashSet<Coord4D>();
 
+
 	/**
 	 * Adds all in-game crafting, smelting and machine recipes.
 	 */
 	public void addRecipes()
 	{
+		String mekanismMaterial = Resource.OSMIUM.getOredictName();
+
 		//Storage Recipes
 
 		if (MekanismConfig.recipes.enableCharcoalBlock) {
@@ -820,7 +823,7 @@ public class Mekanism
 				}));
 
 				MachineType.ADVANCED_FACTORY.addRecipe(new ShapedMekanismRecipe(MekanismUtils.getFactory(FactoryTier.ADVANCED, type), new Object[]{
-						"ECE", "oOo", "ECE", Character.valueOf('E'), "alloyAdvanced", Character.valueOf('C'), MekanismUtils.getControlCircuit(BaseTier.ADVANCED), Character.valueOf('o'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('O'), MekanismUtils.getFactory(FactoryTier.BASIC, type)
+						"ECE", "oOo", "ECE", Character.valueOf('E'), "alloyAdvanced", Character.valueOf('C'), MekanismUtils.getControlCircuit(BaseTier.ADVANCED), Character.valueOf('o'), "ingot" + mekanismMaterial, Character.valueOf('O'), MekanismUtils.getFactory(FactoryTier.BASIC, type)
 				}));
 
 				MachineType.ELITE_FACTORY.addRecipe(new ShapedMekanismRecipe(MekanismUtils.getFactory(FactoryTier.ELITE, type), new Object[]{
@@ -979,7 +982,7 @@ public class Mekanism
 						new ItemStack(MekanismBlocks.PlasticBlock, 1, i), new ItemStack(MekanismBlocks.PlasticBlock, 1, i), new ItemStack(MekanismBlocks.PlasticBlock, 1, i), new ItemStack(Items.glowstone_dust)
 				}));
 				CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(MekanismBlocks.ReinforcedPlasticBlock, 4, i), new Object[]{
-						" P ", "POP", " P ", Character.valueOf('P'), new ItemStack(MekanismBlocks.PlasticBlock, 1, i), Character.valueOf('O'), "dust" + Resource.OSMIUM.getName()
+						" P ", "POP", " P ", Character.valueOf('P'), new ItemStack(MekanismBlocks.PlasticBlock, 1, i), Character.valueOf('O'), "dust" + mekanismMaterial
 				}));
 				CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(MekanismBlocks.RoadPlasticBlock, 3, i), new Object[]{
 						"SSS", "PPP", "SSS", Character.valueOf('S'), Blocks.sand, Character.valueOf('P'), new ItemStack(MekanismBlocks.SlickPlasticBlock, 1, i)
@@ -1222,6 +1225,8 @@ public class Mekanism
 	 */
 	public void registerOreDict()
 	{
+		String mekanismMaterial = Resource.OSMIUM.getOredictName();
+
 		//Add specific items to ore dictionary for recipe usage in other mods.
 		OreDictionary.registerOre("universalCable", new ItemStack(MekanismItems.PartTransmitter, 8, 0));
 		OreDictionary.registerOre("battery", MekanismItems.EnergyTablet.getUnchargedItem());
@@ -1252,7 +1257,7 @@ public class Mekanism
 
 		OreDictionary.registerOre("ingotRefinedObsidian", new ItemStack(MekanismItems.Ingot, 1, 0));
 
-		OreDictionary.registerOre("ingot" + Resource.OSMIUM.getName(), new ItemStack(MekanismItems.Ingot, 1, 1));
+		OreDictionary.registerOre("ingot" + mekanismMaterial, new ItemStack(MekanismItems.Ingot, 1, 1));
 		OreDictionary.registerOre("ingotBronze", new ItemStack(MekanismItems.Ingot, 1, 2));
 		OreDictionary.registerOre("ingotRefinedGlowstone", new ItemStack(MekanismItems.Ingot, 1, 3));
 		OreDictionary.registerOre("ingotSteel", new ItemStack(MekanismItems.Ingot, 1, 4));
@@ -1260,7 +1265,7 @@ public class Mekanism
 		OreDictionary.registerOre("ingotTin", new ItemStack(MekanismItems.Ingot, 1, 6));
 		OreDictionary.registerOre("ingotRefinedLapis", new ItemStack(MekanismItems.Ingot, 1, 7));
 
-		OreDictionary.registerOre("block" + Resource.OSMIUM.getName(), new ItemStack(MekanismBlocks.BasicBlock, 1, 0));
+		OreDictionary.registerOre("block" + mekanismMaterial, new ItemStack(MekanismBlocks.BasicBlock, 1, 0));
 		OreDictionary.registerOre("blockBronze", new ItemStack(MekanismBlocks.BasicBlock, 1, 1));
 		OreDictionary.registerOre("blockRefinedObsidian", new ItemStack(MekanismBlocks.BasicBlock, 1, 2));
 		OreDictionary.registerOre("blockCharcoal", new ItemStack(MekanismBlocks.BasicBlock, 1, 3));
@@ -1271,11 +1276,11 @@ public class Mekanism
 
 		for(Resource resource : Resource.values())
 		{
-			OreDictionary.registerOre("dust" + resource.getName(), new ItemStack(MekanismItems.Dust, 1, resource.ordinal()));
-			OreDictionary.registerOre("dustDirty" + resource.getName(), new ItemStack(MekanismItems.DirtyDust, 1, resource.ordinal()));
-			OreDictionary.registerOre("clump" + resource.getName(), new ItemStack(MekanismItems.Clump, 1, resource.ordinal()));
-			OreDictionary.registerOre("shard" + resource.getName(), new ItemStack(MekanismItems.Shard, 1, resource.ordinal()));
-			OreDictionary.registerOre("crystal" + resource.getName(), new ItemStack(MekanismItems.Crystal, 1, resource.ordinal()));
+			OreDictionary.registerOre("dust" + resource.getOredictName(), new ItemStack(MekanismItems.Dust, 1, resource.ordinal()));
+			OreDictionary.registerOre("dustDirty" + resource.getOredictName(), new ItemStack(MekanismItems.DirtyDust, 1, resource.ordinal()));
+			OreDictionary.registerOre("clump" + resource.getOredictName(), new ItemStack(MekanismItems.Clump, 1, resource.ordinal()));
+			OreDictionary.registerOre("shard" + resource.getOredictName(), new ItemStack(MekanismItems.Shard, 1, resource.ordinal()));
+			OreDictionary.registerOre("crystal" + resource.getOredictName(), new ItemStack(MekanismItems.Crystal, 1, resource.ordinal()));
 		}
 
 		OreDictionary.registerOre("oreCopper", new ItemStack(MekanismBlocks.OreBlock, 1, 1));
@@ -1414,10 +1419,9 @@ public class Mekanism
 		FluidRegistry.registerFluid(new Fluid("steam").setGaseous(true));
 
 		for(Resource resource : Resource.values()) {
-			String name = resource.getName();
 
-			OreGas clean = (OreGas) GasRegistry.register(new OreGas("clean" + name, "oregas." + name.toLowerCase()).setVisible(false));
-			GasRegistry.register(new OreGas(name.toLowerCase(), "oregas." + name.toLowerCase()).setCleanGas(clean).setVisible(false));
+			OreGas clean = (OreGas) GasRegistry.register(new OreGas("clean" + resource.getOredictName(), "oregas." + resource.getOredictName().toLowerCase()).setVisible(false));
+			GasRegistry.register(new OreGas(resource.getOredictName().toLowerCase(), "oregas." + resource.getOredictName().toLowerCase()).setCleanGas(clean).setVisible(false));
 		}
 
 		//Register Gasifyable Items

--- a/src/main/java/mekanism/common/Resource.java
+++ b/src/main/java/mekanism/common/Resource.java
@@ -1,12 +1,14 @@
 package mekanism.common;
 
-import static mekanism.api.MekanismConfig.mekce.PlatReplacement;
+import mekanism.api.MekanismConfig;
+
+import java.util.Objects;
 
 public enum Resource
 {
 	IRON("Iron"),
 	GOLD("Gold"),
-	OSMIUM(PlatReplacement ? "Platinum" : "Osmium"),
+	OSMIUM("Osmium"),
 	COPPER("Copper"),
 	TIN("Tin"),
 	SILVER("Silver"),
@@ -19,11 +21,17 @@ public enum Resource
 		name = s;
 	}
 
+	/**
+	 * Returns resource from a String.
+	 * Used to convert Oregas into their physical output
+	 *
+	 */
 	public static Resource getFromName(String s)
 	{
 		for(Resource r : values())
 		{
-			if(r.name.toLowerCase().equals(s.toLowerCase()))
+			String resourceName = r.getOredictName().toLowerCase();
+			if(resourceName.equals(s.toLowerCase()))
 			{
 				return r;
 			}
@@ -32,8 +40,24 @@ public enum Resource
 		return null;
 	}
 
+	/**
+	 * Returns the name of a resource.
+	 *
+	 */
 	public String getName()
 	{
 		return name;
+	}
+
+	/**
+	 * Returns the oredictionary name of a resource.
+	 *
+	 */
+	public String getOredictName() {
+		String oreName = name;
+		if (MekanismConfig.mekce.PlatReplacement && Objects.equals(oreName, "Osmium"))
+			oreName = "Platinum";
+
+		return oreName;
 	}
 }

--- a/src/main/java/mekanism/common/integration/MekanismHooks.java
+++ b/src/main/java/mekanism/common/integration/MekanismHooks.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 
 import li.cil.oc.api.Driver;
-import mekanism.api.MekanismConfig;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.Mekanism;
 import mekanism.common.MekanismItems;
@@ -103,7 +102,7 @@ public final class MekanismHooks
 		try {
 			for(Resource resource : Resource.values())
 			{
-				Recipes.macerator.addRecipe(new RecipeInputOreDict("clump" + resource.getName()), null, new ItemStack(MekanismItems.DirtyDust, 1, resource.ordinal()));
+				Recipes.macerator.addRecipe(new RecipeInputOreDict("clump" + resource.getOredictName()), null, new ItemStack(MekanismItems.DirtyDust, 1, resource.ordinal()));
 			}
 		} catch(Exception e) {}
 

--- a/src/main/java/mekanism/common/integration/OreDictManager.java
+++ b/src/main/java/mekanism/common/integration/OreDictManager.java
@@ -11,7 +11,6 @@ import java.util.List;
 import mekanism.api.MekanismConfig;
 import mekanism.api.gas.GasRegistry;
 import mekanism.api.gas.GasStack;
-import mekanism.api.gas.OreGas;
 import mekanism.api.infuse.InfuseObject;
 import mekanism.api.infuse.InfuseRegistry;
 import mekanism.api.recipe.RecipeHelper;
@@ -38,6 +37,7 @@ public final class OreDictManager
 	
 	public static void init() {
 		addLogRecipes();
+		String mekanismMaterial = Resource.OSMIUM.getOredictName();
 
 		for (ItemStack ore : OreDictionary.getOres("plankWood")) {
 			if (ore.getHasSubtypes()) {
@@ -84,115 +84,115 @@ public final class OreDictManager
 		}
 
 		for (Resource resource : Resource.values()) {
-			for (ItemStack ore : OreDictionary.getOres("clump" + resource.getName())) {
+			for (ItemStack ore : OreDictionary.getOres("clump" + resource.getOredictName())) {
 				RecipeHandler.addCrusherRecipe(StackUtils.size(ore, 1), new ItemStack(MekanismItems.DirtyDust, 1, resource.ordinal()));
 			}
 
-			for (ItemStack ore : OreDictionary.getOres("shard" + resource.getName())) {
+			for (ItemStack ore : OreDictionary.getOres("shard" + resource.getOredictName())) {
 				RecipeHandler.addPurificationChamberRecipe(StackUtils.size(ore, 1), new ItemStack(MekanismItems.Clump, 1, resource.ordinal()));
 			}
 
-			for (ItemStack ore : OreDictionary.getOres("crystal" + resource.getName())) {
+			for (ItemStack ore : OreDictionary.getOres("crystal" + resource.getOredictName())) {
 				RecipeHandler.addChemicalInjectionChamberRecipe(StackUtils.size(ore, 1), "hydrogenChloride", new ItemStack(MekanismItems.Shard, 1, resource.ordinal()));
 			}
 
-			for (ItemStack ore : OreDictionary.getOres("dustDirty" + resource.getName())) {
+			for (ItemStack ore : OreDictionary.getOres("dustDirty" + resource.getOredictName())) {
 				RecipeHandler.addEnrichmentChamberRecipe(StackUtils.size(ore, 1), new ItemStack(MekanismItems.Dust, 1, resource.ordinal()));
 			}
 
-			for (ItemStack ore : OreDictionary.getOres("ore" + resource.getName())) {
+			for (ItemStack ore : OreDictionary.getOres("ore" + resource.getOredictName())) {
 				RecipeHandler.addEnrichmentChamberRecipe(StackUtils.size(ore, 1), new ItemStack(MekanismItems.Dust, 2, resource.ordinal()));
 				RecipeHandler.addPurificationChamberRecipe(StackUtils.size(ore, 1), new ItemStack(MekanismItems.Clump, 3, resource.ordinal()));
 				RecipeHandler.addChemicalInjectionChamberRecipe(StackUtils.size(ore, 1), "hydrogenChloride", new ItemStack(MekanismItems.Shard, 4, resource.ordinal()));
-				RecipeHandler.addChemicalDissolutionChamberRecipe(StackUtils.size(ore, 1), new GasStack(GasRegistry.getGas(resource.getName().toLowerCase()), 1000));
+				RecipeHandler.addChemicalDissolutionChamberRecipe(StackUtils.size(ore, 1), new GasStack(GasRegistry.getGas(resource.getOredictName().toLowerCase()), 1000));
 			}
 
-			for (ItemStack ore : OreDictionary.getOres("ingot" + resource.getName())) {
+			for (ItemStack ore : OreDictionary.getOres("ingot" + resource.getOredictName())) {
 				RecipeHandler.addCrusherRecipe(StackUtils.size(ore, 1), new ItemStack(MekanismItems.Dust, 1, resource.ordinal()));
 			}
 
 			try {
-				for (ItemStack ore : OreDictionary.getOres("dust" + resource.getName())) {
-					RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 8), StackUtils.size(OreDictionary.getOres("ore" + resource.getName()).get(0), 1));
+				for (ItemStack ore : OreDictionary.getOres("dust" + resource.getOredictName())) {
+					RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 8), StackUtils.size(OreDictionary.getOres("ore" + resource.getOredictName()).get(0), 1));
 				}
 			} catch (Exception e) {}
 		}
 
 		if (MekanismConfig.recipes.enableOsmiumBlock) {
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(MekanismBlocks.BasicBlock, 1, 0), new Object[]{
-					"XXX", "XXX", "XXX", Character.valueOf('X'), "ingot" + Resource.OSMIUM.getName()
+					"XXX", "XXX", "XXX", Character.valueOf('X'), "ingot" + mekanismMaterial
 			}));
 		}
 		if (MekanismConfig.recipes.enableMachineUpgrades) {
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(MekanismItems.SpeedUpgrade), new Object[]{
-					" G ", "ADA", " G ", Character.valueOf('G'), "blockGlass", Character.valueOf('A'), MekanismItems.EnrichedAlloy, Character.valueOf('D'), "dust" + Resource.OSMIUM.getName()
+					" G ", "ADA", " G ", Character.valueOf('G'), "blockGlass", Character.valueOf('A'), MekanismItems.EnrichedAlloy, Character.valueOf('D'), "dust" + mekanismMaterial
 			}));
 		}
 		if (MekanismConfig.recipes.enableMetallurgicInfuser) {
 			BlockMachine.MachineType.METALLURGIC_INFUSER.addRecipe(new ShapedMekanismRecipe(new ItemStack(MekanismBlocks.MachineBlock, 1, 8), new Object[]{
-					"IFI", "ROR", "IFI", Character.valueOf('I'), "ingotIron", Character.valueOf('F'), Blocks.furnace, Character.valueOf('R'), "dustRedstone", Character.valueOf('O'), "ingot" + Resource.OSMIUM.getName()
+					"IFI", "ROR", "IFI", Character.valueOf('I'), "ingotIron", Character.valueOf('F'), Blocks.furnace, Character.valueOf('R'), "dustRedstone", Character.valueOf('O'), "ingot" + mekanismMaterial
 			}));
 		}
 
 		if (MekanismConfig.recipes.enablePurificationChamber) {
 			BlockMachine.MachineType.PURIFICATION_CHAMBER.addRecipe(new ShapedMekanismRecipe(new ItemStack(MekanismBlocks.MachineBlock, 1, 9), new Object[]{
-					"ECE", "ORO", "ECE", Character.valueOf('C'), MekanismUtils.getControlCircuit(Tier.BaseTier.ADVANCED), Character.valueOf('E'), "alloyAdvanced", Character.valueOf('O'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('R'), new ItemStack(MekanismBlocks.MachineBlock, 1, 0)
+					"ECE", "ORO", "ECE", Character.valueOf('C'), MekanismUtils.getControlCircuit(Tier.BaseTier.ADVANCED), Character.valueOf('E'), "alloyAdvanced", Character.valueOf('O'), "ingot" + mekanismMaterial, Character.valueOf('R'), new ItemStack(MekanismBlocks.MachineBlock, 1, 0)
 			}));
 		}
 
 		if (MekanismConfig.recipes.enableSteelCasing) {
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(MekanismBlocks.BasicBlock, 1, 8), new Object[]{
-					"SGS", "GPG", "SGS", Character.valueOf('S'), "ingotSteel", Character.valueOf('P'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('G'), "blockGlass"
+					"SGS", "GPG", "SGS", Character.valueOf('S'), "ingotSteel", Character.valueOf('P'), "ingot" + mekanismMaterial, Character.valueOf('G'), "blockGlass"
 			}));
 		}
 
 		if (MekanismConfig.recipes.enableElectricPump) {
 			BlockMachine.MachineType.ELECTRIC_PUMP.addRecipe(new ShapedMekanismRecipe(new ItemStack(MekanismBlocks.MachineBlock, 1, 12), new Object[]{
-					" B ", "ECE", "OOO", Character.valueOf('B'), Items.bucket, Character.valueOf('E'), MekanismItems.EnrichedAlloy, Character.valueOf('C'), new ItemStack(MekanismBlocks.BasicBlock, 1, 8), Character.valueOf('O'), "ingot" + Resource.OSMIUM.getName()
+					" B ", "ECE", "OOO", Character.valueOf('B'), Items.bucket, Character.valueOf('E'), MekanismItems.EnrichedAlloy, Character.valueOf('C'), new ItemStack(MekanismBlocks.BasicBlock, 1, 8), Character.valueOf('O'), "ingot" + mekanismMaterial
 			}));
 		}
 
 		if (MekanismConfig.recipes.enableElectroliticCore) {
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(MekanismItems.ElectrolyticCore), new Object[]{
-					"EPE", "IEG", "EPE", Character.valueOf('E'), MekanismItems.EnrichedAlloy, Character.valueOf('P'), "dust" + Resource.OSMIUM.getName(), Character.valueOf('I'), "dustIron", Character.valueOf('G'), "dustGold"
+					"EPE", "IEG", "EPE", Character.valueOf('E'), MekanismItems.EnrichedAlloy, Character.valueOf('P'), "dust" + mekanismMaterial, Character.valueOf('I'), "dustIron", Character.valueOf('G'), "dustGold"
 			}));
 		}
 
 		CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(Blocks.rail, 24), new Object[]{
-				"O O", "OSO", "O O", Character.valueOf('O'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('S'), "stickWood"
+				"O O", "OSO", "O O", Character.valueOf('O'), "ingot" + mekanismMaterial, Character.valueOf('S'), "stickWood"
 		}));
 
 		if (MekanismConfig.recipes.enableGaugeDropper) {
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(MekanismItems.GaugeDropper.getEmptyItem(), new Object[]{
-					" O ", "G G", "GGG", Character.valueOf('O'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('G'), "paneGlass"
+					" O ", "G G", "GGG", Character.valueOf('O'), "ingot" + mekanismMaterial, Character.valueOf('G'), "paneGlass"
 			}));
 		}
 
 		if (MekanismConfig.recipes.enableTierInstaller) {
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(MekanismItems.TierInstaller, 1, 1), new Object[]{
-					"ECE", "oWo", "ECE", Character.valueOf('E'), "alloyAdvanced", Character.valueOf('C'), MekanismUtils.getControlCircuit(Tier.BaseTier.ADVANCED), Character.valueOf('o'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('W'), "plankWood"
+					"ECE", "oWo", "ECE", Character.valueOf('E'), "alloyAdvanced", Character.valueOf('C'), MekanismUtils.getControlCircuit(Tier.BaseTier.ADVANCED), Character.valueOf('o'), "ingot" + mekanismMaterial, Character.valueOf('W'), "plankWood"
 			}));
 		}
 
 		if (MekanismConfig.recipes.enableEnergyCubes) {
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(MekanismUtils.getEnergyCube(Tier.EnergyCubeTier.ADVANCED), new Object[]{
-					"ETE", "oBo", "ETE", Character.valueOf('E'), "alloyAdvanced", Character.valueOf('o'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('T'), MekanismItems.EnergyTablet.getUnchargedItem(), Character.valueOf('B'), MekanismUtils.getEnergyCube(Tier.EnergyCubeTier.BASIC)
+					"ETE", "oBo", "ETE", Character.valueOf('E'), "alloyAdvanced", Character.valueOf('o'), "ingot" + mekanismMaterial, Character.valueOf('T'), MekanismItems.EnergyTablet.getUnchargedItem(), Character.valueOf('B'), MekanismUtils.getEnergyCube(Tier.EnergyCubeTier.BASIC)
 			}));
 		}
 
 		//Gas Tank Recipes
 		if (MekanismConfig.recipes.enableGasTanks) {
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(MekanismUtils.getEmptyGasTank(Tier.GasTankTier.BASIC), new Object[]{
-					"APA", "P P", "APA", Character.valueOf('P'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('A'), "alloyBasic"
+					"APA", "P P", "APA", Character.valueOf('P'), "ingot" + mekanismMaterial, Character.valueOf('A'), "alloyBasic"
 			}));
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(MekanismUtils.getEmptyGasTank(Tier.GasTankTier.ADVANCED), new Object[]{
-					"APA", "PTP", "APA", Character.valueOf('P'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('A'), "alloyAdvanced", Character.valueOf('T'), MekanismUtils.getEmptyGasTank(Tier.GasTankTier.BASIC)
+					"APA", "PTP", "APA", Character.valueOf('P'), "ingot" + mekanismMaterial, Character.valueOf('A'), "alloyAdvanced", Character.valueOf('T'), MekanismUtils.getEmptyGasTank(Tier.GasTankTier.BASIC)
 			}));
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(MekanismUtils.getEmptyGasTank(Tier.GasTankTier.ELITE), new Object[]{
-					"APA", "PTP", "APA", Character.valueOf('P'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('A'), "alloyElite", Character.valueOf('T'), MekanismUtils.getEmptyGasTank(Tier.GasTankTier.ADVANCED)
+					"APA", "PTP", "APA", Character.valueOf('P'), "ingot" + mekanismMaterial, Character.valueOf('A'), "alloyElite", Character.valueOf('T'), MekanismUtils.getEmptyGasTank(Tier.GasTankTier.ADVANCED)
 			}));
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(MekanismUtils.getEmptyGasTank(Tier.GasTankTier.ULTIMATE), new Object[]{
-					"APA", "PTP", "APA", Character.valueOf('P'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('A'), "alloyUltimate", Character.valueOf('T'), MekanismUtils.getEmptyGasTank(Tier.GasTankTier.ELITE)
+					"APA", "PTP", "APA", Character.valueOf('P'), "ingot" + mekanismMaterial, Character.valueOf('A'), "alloyUltimate", Character.valueOf('T'), MekanismUtils.getEmptyGasTank(Tier.GasTankTier.ELITE)
 			}));
 		}
 
@@ -205,7 +205,7 @@ public final class OreDictManager
 			}
 		} else {
 
-			for (ItemStack ore : OreDictionary.getOres("ingot" + Resource.OSMIUM.getName())) {
+			for (ItemStack ore : OreDictionary.getOres("ingot" + mekanismMaterial)) {
 				RecipeHandler.addMetallurgicInfuserRecipe(InfuseRegistry.get("REDSTONE"), 10, StackUtils.size(ore, 1), new ItemStack(MekanismItems.ControlCircuit, 1, 0));
 			}
 		}

--- a/src/main/java/mekanism/common/recipe/machines/OsmiumCompressorRecipe.java
+++ b/src/main/java/mekanism/common/recipe/machines/OsmiumCompressorRecipe.java
@@ -1,6 +1,5 @@
 package mekanism.common.recipe.machines;
 
-import mekanism.api.MekanismConfig;
 import mekanism.common.Resource;
 import mekanism.common.recipe.inputs.AdvancedMachineInput;
 import mekanism.common.recipe.outputs.ItemStackOutput;
@@ -15,7 +14,7 @@ public class OsmiumCompressorRecipe extends AdvancedMachineRecipe<OsmiumCompress
 
 	public OsmiumCompressorRecipe(ItemStack input, ItemStack output)
 	{
-		super(input, "liquid" + Resource.OSMIUM.getName(), output);
+		super(input, "liquid" + Resource.OSMIUM.getOredictName(), output);
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityOsmiumCompressor.java
+++ b/src/main/java/mekanism/common/tile/TileEntityOsmiumCompressor.java
@@ -2,7 +2,6 @@ package mekanism.common.tile;
 
 import java.util.Map;
 
-import mekanism.api.MekanismConfig;
 import mekanism.api.MekanismConfig.usage;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
@@ -31,15 +30,17 @@ public class TileEntityOsmiumCompressor extends TileEntityAdvancedElectricMachin
 	@Override
 	public GasStack getItemGas(ItemStack itemstack)
 	{
-		for (ItemStack ore : OreDictionary.getOres("ingot" + Resource.OSMIUM.getName())) {
+		String mekanismMaterial = Resource.OSMIUM.getOredictName();
+
+		for (ItemStack ore : OreDictionary.getOres("ingot" + mekanismMaterial)) {
 			if (ore.isItemEqual(itemstack)) {
-				return new GasStack(GasRegistry.getGas("liquid" + Resource.OSMIUM.getName()), 200);
+				return new GasStack(GasRegistry.getGas("liquid" + mekanismMaterial), 200);
 			}
 		}
 
-		for (ItemStack ore : OreDictionary.getOres("block" + Resource.OSMIUM.getName())) {
+		for (ItemStack ore : OreDictionary.getOres("block" + mekanismMaterial)) {
 			if (ore.isItemEqual(itemstack)) {
-				return new GasStack(GasRegistry.getGas("liquid" + Resource.OSMIUM.getName()), 1800);
+				return new GasStack(GasRegistry.getGas("liquid" + mekanismMaterial), 1800);
 			}
 		}
 

--- a/src/main/java/mekanism/generators/common/MekanismGenerators.java
+++ b/src/main/java/mekanism/generators/common/MekanismGenerators.java
@@ -112,15 +112,17 @@ public class MekanismGenerators implements IModule
 	
 	public void addRecipes()
 	{
+		String mekanismMaterial = Resource.OSMIUM.getOredictName();
+
 		if (generatorsrecipes.enableHeatGenerator) {
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(GeneratorsBlocks.Generator, 1, 0), new Object[]{
-					"III", "WOW", "CFC", Character.valueOf('I'), "ingotIron", Character.valueOf('C'), "ingotCopper", Character.valueOf('O'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('F'), Blocks.furnace, Character.valueOf('W'), "plankWood"
+					"III", "WOW", "CFC", Character.valueOf('I'), "ingotIron", Character.valueOf('C'), "ingotCopper", Character.valueOf('O'), "ingot" + mekanismMaterial, Character.valueOf('F'), Blocks.furnace, Character.valueOf('W'), "plankWood"
 			}));
 		}
 
 		if (generatorsrecipes.enableSolarGenerator) {
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(GeneratorsBlocks.Generator, 1, 1), new Object[]{
-					"SSS", "AIA", "PEP", Character.valueOf('S'), GeneratorsItems.SolarPanel, Character.valueOf('A'), MekanismItems.EnrichedAlloy, Character.valueOf('I'), "ingotIron", Character.valueOf('P'), "dust" + Resource.OSMIUM.getName(), Character.valueOf('E'), MekanismItems.EnergyTablet.getUnchargedItem()
+					"SSS", "AIA", "PEP", Character.valueOf('S'), GeneratorsItems.SolarPanel, Character.valueOf('A'), MekanismItems.EnrichedAlloy, Character.valueOf('I'), "ingotIron", Character.valueOf('P'), "dust" + mekanismMaterial, Character.valueOf('E'), MekanismItems.EnergyTablet.getUnchargedItem()
 			}));
 		}
 
@@ -138,19 +140,19 @@ public class MekanismGenerators implements IModule
 
 		if (generatorsrecipes.enableGasGenerator) {
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(GeneratorsBlocks.Generator, 1, 3), new Object[]{
-					"PEP", "ICI", "PEP", Character.valueOf('P'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('E'), MekanismItems.EnrichedAlloy, Character.valueOf('I'), new ItemStack(MekanismBlocks.BasicBlock, 1, 8), Character.valueOf('C'), MekanismItems.ElectrolyticCore
+					"PEP", "ICI", "PEP", Character.valueOf('P'), "ingot" + mekanismMaterial, Character.valueOf('E'), MekanismItems.EnrichedAlloy, Character.valueOf('I'), new ItemStack(MekanismBlocks.BasicBlock, 1, 8), Character.valueOf('C'), MekanismItems.ElectrolyticCore
 			}));
 		}
 
 		if (generatorsrecipes.enableSolarPanel) {
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(GeneratorsItems.SolarPanel), new Object[]{
-					"GGG", "RAR", "PPP", Character.valueOf('G'), "paneGlass", Character.valueOf('R'), "dustRedstone", Character.valueOf('A'), MekanismItems.EnrichedAlloy, Character.valueOf('P'), "ingot" + Resource.OSMIUM.getName()
+					"GGG", "RAR", "PPP", Character.valueOf('G'), "paneGlass", Character.valueOf('R'), "dustRedstone", Character.valueOf('A'), MekanismItems.EnrichedAlloy, Character.valueOf('P'), "ingot" + mekanismMaterial
 			}));
 		}
 
 		if (generatorsrecipes.enableWindGenerator) {
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(GeneratorsBlocks.Generator, 1, 6), new Object[]{
-					" O ", "OAO", "ECE", Character.valueOf('O'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('A'), MekanismItems.EnrichedAlloy, Character.valueOf('E'), MekanismItems.EnergyTablet.getUnchargedItem(), Character.valueOf('C'), MekanismUtils.getControlCircuit(BaseTier.BASIC)
+					" O ", "OAO", "ECE", Character.valueOf('O'), "ingot" + mekanismMaterial, Character.valueOf('A'), MekanismItems.EnrichedAlloy, Character.valueOf('E'), MekanismItems.EnergyTablet.getUnchargedItem(), Character.valueOf('C'), MekanismUtils.getControlCircuit(BaseTier.BASIC)
 			}));
 		}
 
@@ -180,7 +182,7 @@ public class MekanismGenerators implements IModule
 
 		if (generatorsrecipes.enableTurbineCasing) {
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(GeneratorsBlocks.Generator, 4, 10), new Object[]{
-					" S ", "SOS", " S ", Character.valueOf('S'), "ingotSteel", Character.valueOf('O'), "ingot" + Resource.OSMIUM.getName()
+					" S ", "SOS", " S ", Character.valueOf('S'), "ingotSteel", Character.valueOf('O'), "ingot" + mekanismMaterial
 			}));
 		}
 

--- a/src/main/java/mekanism/tools/common/MekanismTools.java
+++ b/src/main/java/mekanism/tools/common/MekanismTools.java
@@ -93,6 +93,8 @@ public class MekanismTools implements IModule
 	
 	public void addRecipes()
 	{
+		String mekanismMaterial = Resource.OSMIUM.getOredictName();
+
 		//Crafting Recipes
 		//Base
 		CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(ToolsItems.WoodPaxel, 1), new Object[] {
@@ -207,37 +209,37 @@ public class MekanismTools implements IModule
 			"X", "X", "T", Character.valueOf('X'), new ItemStack(Items.dye, 1, 4), Character.valueOf('T'), Items.stick
 		}));
 
-		if(OreDictionary.doesOreNameExist("ingot" + Resource.OSMIUM.getName())) {
+		if(OreDictionary.doesOreNameExist("ingot" + mekanismMaterial)) {
 			//Osmium
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(ToolsItems.OsmiumPaxel, 1), new Object[]{
 					"XYZ", " T ", " T ", Character.valueOf('X'), ToolsItems.OsmiumAxe, Character.valueOf('Y'), ToolsItems.OsmiumPickaxe, Character.valueOf('Z'), ToolsItems.OsmiumShovel, Character.valueOf('T'), Items.stick
 			}));
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(ToolsItems.OsmiumPickaxe, 1), new Object[]{
-					"XXX", " T ", " T ", Character.valueOf('X'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('T'), Items.stick
+					"XXX", " T ", " T ", Character.valueOf('X'), "ingot" + mekanismMaterial, Character.valueOf('T'), Items.stick
 			}));
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(ToolsItems.OsmiumAxe, 1), new Object[]{
-					"XX", "XT", " T", Character.valueOf('X'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('T'), Items.stick
+					"XX", "XT", " T", Character.valueOf('X'), "ingot" + mekanismMaterial, Character.valueOf('T'), Items.stick
 			}));
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(ToolsItems.OsmiumShovel, 1), new Object[]{
-					"X", "T", "T", Character.valueOf('X'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('T'), Items.stick
+					"X", "T", "T", Character.valueOf('X'), "ingot" + mekanismMaterial, Character.valueOf('T'), Items.stick
 			}));
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(ToolsItems.OsmiumHoe, 1), new Object[]{
-					"XX", " T", " T", Character.valueOf('X'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('T'), Items.stick
+					"XX", " T", " T", Character.valueOf('X'), "ingot" + mekanismMaterial, Character.valueOf('T'), Items.stick
 			}));
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(ToolsItems.OsmiumSword, 1), new Object[]{
-					"X", "X", "T", Character.valueOf('X'), "ingot" + Resource.OSMIUM.getName(), Character.valueOf('T'), Items.stick
+					"X", "X", "T", Character.valueOf('X'), "ingot" + mekanismMaterial, Character.valueOf('T'), Items.stick
 			}));
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(ToolsItems.OsmiumHelmet, 1), new Object[]{
-					"***", "* *", Character.valueOf('*'), "ingot" + Resource.OSMIUM.getName()
+					"***", "* *", Character.valueOf('*'), "ingot" + mekanismMaterial
 			}));
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(ToolsItems.OsmiumChestplate, 1), new Object[]{
-					"* *", "***", "***", Character.valueOf('*'), "ingot" + Resource.OSMIUM.getName()
+					"* *", "***", "***", Character.valueOf('*'), "ingot" + mekanismMaterial
 			}));
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(ToolsItems.OsmiumLeggings, 1), new Object[]{
-					"***", "* *", "* *", Character.valueOf('*'), "ingot" + Resource.OSMIUM.getName()
+					"***", "* *", "* *", Character.valueOf('*'), "ingot" + mekanismMaterial
 			}));
 			CraftingManager.getInstance().getRecipeList().add(new ShapedMekanismRecipe(new ItemStack(ToolsItems.OsmiumBoots, 1), new Object[]{
-					"* *", "* *", Character.valueOf('*'), "ingot" + Resource.OSMIUM.getName()
+					"* *", "* *", Character.valueOf('*'), "ingot" + mekanismMaterial
 			}));
 		}
 		//Bronze


### PR DESCRIPTION
- Loads config before gas and item registration.
- Separates the `PlatReplacement` config into its own method.

This solves the problem where the `PlatReplacement` config was always false as a result of the configs being initiated much much later.

The reason `getOredictName()` is introduced is for cleaner code and because `getName()` is used to register icons and names which should not be touched.
I've also added comments indicating exactly what each method is being used for clarity.