### PR TITLE
Add missing Gas API methods

### DIFF
--- a/src/main/java/mekanism/api/gas/GasTank.java
+++ b/src/main/java/mekanism/api/gas/GasTank.java
@@ -7,7 +7,7 @@ import net.minecraft.nbt.NBTTagCompound;
  * @author aidancbrady
  *
  */
-public class GasTank
+public class GasTank implements GasTankInfo
 {
 	public GasStack stored;
 

--- a/src/main/java/mekanism/api/gas/GasTankInfo.java
+++ b/src/main/java/mekanism/api/gas/GasTankInfo.java
@@ -1,0 +1,28 @@
+package mekanism.api.gas;
+
+import javax.annotation.Nullable;
+
+public interface GasTankInfo {
+	
+	/**
+	 * Retrieve the stored gas stack. DO NOT MODIFY.
+	 * 
+	 * @return the stored gas, or null
+	 */
+	@Nullable
+	GasStack getGas();
+
+	/**
+	 * Gets the amount of gas stored by this GasTank
+	 * 
+	 * @return amount of gas stored
+	 */
+	int getStored();
+
+	/**
+	 * Gets the maximum amount of gas this tank can hold
+	 * 
+	 * @return - max gas
+	 */
+	int getMaxGas();
+}

--- a/src/main/java/mekanism/api/gas/IGasTankInfoProvider.java
+++ b/src/main/java/mekanism/api/gas/IGasTankInfoProvider.java
@@ -1,0 +1,23 @@
+package mekanism.api.gas;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Implement this if your tile entity extends IGasHandler.
+ * Backported from 1.12.2, separated from IGasHandler to maintain compatibility.
+ */
+public interface IGasTankInfoProvider
+{
+
+	GasTankInfo[] NONE = new GasTankInfo[0];
+
+	/**
+     * Gets the tanks present on this handler. READ ONLY. DO NOT MODIFY.
+     *
+     * @return an array of GasTankInfo elements corresponding to all tanks.
+     */
+	@Nonnull
+	default GasTankInfo[] getTankInfo() {
+		return NONE;
+	}
+}

--- a/src/main/java/mekanism/common/multipart/PartPressurizedTube.java
+++ b/src/main/java/mekanism/common/multipart/PartPressurizedTube.java
@@ -2,13 +2,17 @@ package mekanism.common.multipart;
 
 import java.util.Collection;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.MekanismConfig.client;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasNetwork;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.GasTransmission;
 import mekanism.api.gas.IGasHandler;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.client.render.RenderPartTransmitter;
 import mekanism.common.Tier;
@@ -26,7 +30,7 @@ import codechicken.lib.vec.Vector3;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-public class PartPressurizedTube extends PartTransmitter<IGasHandler, GasNetwork> implements IGasHandler
+public class PartPressurizedTube extends PartTransmitter<IGasHandler, GasNetwork> implements IGasHandler, IGasTankInfoProvider
 {
 	public Tier.TubeTier tier = Tier.TubeTier.BASIC;
 	
@@ -301,6 +305,20 @@ public class PartPressurizedTube extends PartTransmitter<IGasHandler, GasNetwork
 	public boolean canDrawGas(ForgeDirection side, Gas type)
 	{
 		return false;
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		if (getTransmitter().hasTransmitterNetwork())
+		{
+			GasNetwork network = getTransmitter().getTransmitterNetwork();
+			GasTank networkTank = new GasTank(network.getCapacity());
+			networkTank.setGas(network.buffer);
+			return new GasTankInfo[] {networkTank};
+		}
+		return new GasTankInfo[] {buffer};
 	}
 
 	public int takeGas(GasStack gasStack, boolean doEmit)

--- a/src/main/java/mekanism/common/tile/TileEntityAdvancedElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/TileEntityAdvancedElectricMachine.java
@@ -4,11 +4,15 @@ import io.netty.buffer.ByteBuf;
 
 import java.util.ArrayList;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.EnumColor;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.IGasHandler;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.MekanismBlocks;
@@ -35,7 +39,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public abstract class TileEntityAdvancedElectricMachine<RECIPE extends AdvancedMachineRecipe<RECIPE>> extends TileEntityBasicMachine<AdvancedMachineInput, ItemStackOutput, RECIPE> implements IGasHandler, ITubeConnection, ITierUpgradeable
+public abstract class TileEntityAdvancedElectricMachine<RECIPE extends AdvancedMachineRecipe<RECIPE>> extends TileEntityBasicMachine<AdvancedMachineInput, ItemStackOutput, RECIPE> implements IGasHandler, IGasTankInfoProvider, ITubeConnection, ITierUpgradeable
 {
 	/** How much secondary energy (fuel) this machine uses per tick, not including upgrades. */
 	public int BASE_SECONDARY_ENERGY_PER_TICK;
@@ -436,6 +440,13 @@ public abstract class TileEntityAdvancedElectricMachine<RECIPE extends AdvancedM
 	public boolean canDrawGas(ForgeDirection side, Gas type)
 	{
 		return false;
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return new GasTankInfo[] {gasTank};
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityAmbientAccumulator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityAmbientAccumulator.java
@@ -5,10 +5,14 @@ import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.Random;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.IGasHandler;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.IntegerInput;
@@ -16,7 +20,7 @@ import mekanism.common.recipe.machines.AmbientGasRecipe;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class TileEntityAmbientAccumulator extends TileEntityContainerBlock implements IGasHandler, ITubeConnection
+public class TileEntityAmbientAccumulator extends TileEntityContainerBlock implements IGasHandler, IGasTankInfoProvider, ITubeConnection
 {
 	public GasTank collectedGas = new GasTank(1000);
 
@@ -84,6 +88,13 @@ public class TileEntityAmbientAccumulator extends TileEntityContainerBlock imple
 	public boolean canDrawGas(ForgeDirection side, Gas type)
 	{
 		return type == collectedGas.getGasType();
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return new GasTankInfo[] {collectedGas};
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
@@ -4,6 +4,8 @@ import io.netty.buffer.ByteBuf;
 
 import java.util.ArrayList;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigCardAccess;
@@ -13,9 +15,11 @@ import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.GasTransmission;
 import mekanism.api.gas.IGasHandler;
 import mekanism.api.gas.IGasItem;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.Mekanism;
@@ -43,7 +47,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class TileEntityChemicalCrystallizer extends TileEntityNoisyElectricBlock implements IGasHandler, ITubeConnection, IRedstoneControl, ISideConfiguration, IUpgradeTile, ISustainedData, ITankManager, IConfigCardAccess, ISecurityTile
+public class TileEntityChemicalCrystallizer extends TileEntityNoisyElectricBlock implements IGasHandler, IGasTankInfoProvider, ITubeConnection, IRedstoneControl, ISideConfiguration, IUpgradeTile, ISustainedData, ITankManager, IConfigCardAccess, ISecurityTile
 {
 	public static final int MAX_GAS = 10000;
 	
@@ -388,6 +392,13 @@ public class TileEntityChemicalCrystallizer extends TileEntityNoisyElectricBlock
 	public boolean canDrawGas(ForgeDirection side, Gas type)
 	{
 		return false;
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return new GasTankInfo[] {inputTank};
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalDissolutionChamber.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalDissolutionChamber.java
@@ -4,6 +4,8 @@ import io.netty.buffer.ByteBuf;
 
 import java.util.ArrayList;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.Coord4D;
 import mekanism.api.MekanismConfig.usage;
 import mekanism.api.Range4D;
@@ -11,9 +13,11 @@ import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.GasTransmission;
 import mekanism.api.gas.IGasHandler;
 import mekanism.api.gas.IGasItem;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.common.Mekanism;
 import mekanism.common.Upgrade;
@@ -39,7 +43,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class TileEntityChemicalDissolutionChamber extends TileEntityNoisyElectricBlock implements ITubeConnection, IRedstoneControl, IGasHandler, IUpgradeTile, ISustainedData, ITankManager, ISecurityTile
+public class TileEntityChemicalDissolutionChamber extends TileEntityNoisyElectricBlock implements ITubeConnection, IRedstoneControl, IGasHandler, IGasTankInfoProvider, IUpgradeTile, ISustainedData, ITankManager, ISecurityTile
 {
 	public GasTank injectTank = new GasTank(MAX_GAS);
 	public GasTank outputTank = new GasTank(MAX_GAS);
@@ -451,6 +455,13 @@ public class TileEntityChemicalDissolutionChamber extends TileEntityNoisyElectri
 	public boolean canDrawGas(ForgeDirection side, Gas type)
 	{
 		return false;
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return new GasTankInfo[] {injectTank, outputTank};
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalInfuser.java
@@ -5,6 +5,8 @@ import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.Coord4D;
 import mekanism.api.MekanismConfig.usage;
 import mekanism.api.Range4D;
@@ -12,9 +14,11 @@ import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.GasTransmission;
 import mekanism.api.gas.IGasHandler;
 import mekanism.api.gas.IGasItem;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.common.Mekanism;
 import mekanism.common.Upgrade;
@@ -39,7 +43,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class TileEntityChemicalInfuser extends TileEntityNoisyElectricBlock implements IGasHandler, ITubeConnection, IRedstoneControl, ISustainedData, IUpgradeTile, IUpgradeInfoHandler, ITankManager, ISecurityTile
+public class TileEntityChemicalInfuser extends TileEntityNoisyElectricBlock implements IGasHandler, IGasTankInfoProvider, ITubeConnection, IRedstoneControl, ISustainedData, IUpgradeTile, IUpgradeInfoHandler, ITankManager, ISecurityTile
 {
 	public GasTank leftTank = new GasTank(MAX_GAS);
 	public GasTank rightTank = new GasTank(MAX_GAS);
@@ -447,6 +451,13 @@ public class TileEntityChemicalInfuser extends TileEntityNoisyElectricBlock impl
 	public boolean canDrawGas(ForgeDirection side, Gas type)
 	{
 		return getTank(side) != null && getTank(side) == centerTank ? getTank(side).canDraw(type) : false;
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return new GasTankInfo[] {leftTank, rightTank, centerTank};
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalOxidizer.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalOxidizer.java
@@ -4,15 +4,19 @@ import io.netty.buffer.ByteBuf;
 
 import java.util.ArrayList;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.Coord4D;
 import mekanism.api.MekanismConfig.usage;
 import mekanism.api.Range4D;
 import mekanism.api.gas.GasRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.GasTransmission;
 import mekanism.api.gas.IGasHandler;
 import mekanism.api.gas.IGasItem;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.common.Mekanism;
 import mekanism.common.Upgrade;
@@ -36,7 +40,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class TileEntityChemicalOxidizer extends TileEntityNoisyElectricBlock implements ITubeConnection, IRedstoneControl, IUpgradeTile, ISustainedData, ITankManager, ISecurityTile
+public class TileEntityChemicalOxidizer extends TileEntityNoisyElectricBlock implements ITubeConnection, IRedstoneControl, IUpgradeTile, ISustainedData, ITankManager, ISecurityTile, IGasTankInfoProvider
 {
 	public GasTank gasTank = new GasTank(MAX_GAS);
 
@@ -407,6 +411,13 @@ public class TileEntityChemicalOxidizer extends TileEntityNoisyElectricBlock imp
 	public Object[] getTanks() 
 	{
 		return new Object[] {gasTank};
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return new GasTankInfo[] {gasTank};
 	}
 	
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalWasher.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalWasher.java
@@ -5,6 +5,8 @@ import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.Coord4D;
 import mekanism.api.MekanismConfig.usage;
 import mekanism.api.Range4D;
@@ -12,9 +14,11 @@ import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.GasTransmission;
 import mekanism.api.gas.IGasHandler;
 import mekanism.api.gas.IGasItem;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.common.Mekanism;
 import mekanism.common.Upgrade;
@@ -50,7 +54,7 @@ import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidContainerItem;
 import net.minecraftforge.fluids.IFluidHandler;
 
-public class TileEntityChemicalWasher extends TileEntityNoisyElectricBlock implements IGasHandler, ITubeConnection, IRedstoneControl, IFluidHandler, IUpgradeTile, ISustainedData, IUpgradeInfoHandler, ITankManager, ISecurityTile
+public class TileEntityChemicalWasher extends TileEntityNoisyElectricBlock implements IGasHandler, IGasTankInfoProvider, ITubeConnection, IRedstoneControl, IFluidHandler, IUpgradeTile, ISustainedData, IUpgradeInfoHandler, ITankManager, ISecurityTile
 {
 	public FluidTank fluidTank = new FluidTank(MAX_FLUID);
 	public GasTank inputTank = new GasTank(MAX_GAS);
@@ -455,6 +459,13 @@ public class TileEntityChemicalWasher extends TileEntityNoisyElectricBlock imple
 	public boolean canDrawGas(ForgeDirection side, Gas type)
 	{
 		return getTank(side) == outputTank ? getTank(side).canDraw(type) : false;
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return new GasTankInfo[] {inputTank, outputTank};
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.Coord4D;
 import mekanism.api.MekanismConfig;
 import mekanism.api.Range4D;
@@ -13,9 +15,11 @@ import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.GasTransmission;
 import mekanism.api.gas.IGasHandler;
 import mekanism.api.gas.IGasItem;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.common.Mekanism;
 import mekanism.common.Upgrade;
@@ -50,7 +54,7 @@ import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidContainerItem;
 import net.minecraftforge.fluids.IFluidHandler;
 
-public class TileEntityElectrolyticSeparator extends TileEntityElectricBlock implements IFluidHandler, IComputerIntegration, ITubeConnection, ISustainedData, IGasHandler, IUpgradeTile, IUpgradeInfoHandler, ITankManager, IRedstoneControl, IActiveState, ISecurityTile
+public class TileEntityElectrolyticSeparator extends TileEntityElectricBlock implements IFluidHandler, IComputerIntegration, ITubeConnection, ISustainedData, IGasHandler, IGasTankInfoProvider, IUpgradeTile, IUpgradeInfoHandler, ITankManager, IRedstoneControl, IActiveState, ISecurityTile
 {
 	/** This separator's water slot. */
 	public FluidTank fluidTank = new FluidTank(24000);
@@ -745,6 +749,13 @@ public class TileEntityElectrolyticSeparator extends TileEntityElectricBlock imp
 		}
 
 		return false;
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return new GasTankInfo[] {leftTank, rightTank};
 	}
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigCardAccess.ISpecialConfigData;
@@ -15,9 +17,11 @@ import mekanism.api.Range4D;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.GasTransmission;
 import mekanism.api.gas.IGasHandler;
 import mekanism.api.gas.IGasItem;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.api.infuse.InfuseObject;
 import mekanism.api.infuse.InfuseRegistry;
@@ -65,7 +69,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-public class TileEntityFactory extends TileEntityNoisyElectricBlock implements IComputerIntegration, ISideConfiguration, IUpgradeTile, IRedstoneControl, IGasHandler, ITubeConnection, ISpecialConfigData, ISecurityTile, ITierUpgradeable
+public class TileEntityFactory extends TileEntityNoisyElectricBlock implements IComputerIntegration, ISideConfiguration, IUpgradeTile, IRedstoneControl, IGasHandler, IGasTankInfoProvider, ITubeConnection, ISpecialConfigData, ISecurityTile, ITierUpgradeable
 {
 	/** This Factory's tier. */
 	public FactoryTier tier;
@@ -1159,6 +1163,13 @@ public class TileEntityFactory extends TileEntityNoisyElectricBlock implements I
 	public boolean canDrawGas(ForgeDirection side, Gas type)
 	{
 		return false;
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return new GasTankInfo[] {gasTank};
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityGasTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityGasTank.java
@@ -4,6 +4,8 @@ import io.netty.buffer.ByteBuf;
 
 import java.util.ArrayList;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.Range4D;
@@ -11,9 +13,11 @@ import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.GasTransmission;
 import mekanism.api.gas.IGasHandler;
 import mekanism.api.gas.IGasItem;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.Mekanism;
@@ -38,7 +42,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.MathHelper;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class TileEntityGasTank extends TileEntityContainerBlock implements IGasHandler, ITubeConnection, IRedstoneControl, ISideConfiguration, ISecurityTile, ITierUpgradeable
+public class TileEntityGasTank extends TileEntityContainerBlock implements IGasHandler, IGasTankInfoProvider, ITubeConnection, IRedstoneControl, ISideConfiguration, ISecurityTile, ITierUpgradeable
 {
 	public enum GasMode
 	{
@@ -242,6 +246,13 @@ public class TileEntityGasTank extends TileEntityContainerBlock implements IGasH
 		}
 
 		return false;
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return new GasTankInfo[] {gasTank};
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityPRC.java
+++ b/src/main/java/mekanism/common/tile/TileEntityPRC.java
@@ -5,13 +5,17 @@ import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.EnumColor;
 import mekanism.api.MekanismConfig.usage;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.IGasHandler;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.SideData;
@@ -42,7 +46,7 @@ import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
-public class TileEntityPRC extends TileEntityBasicMachine<PressurizedInput, PressurizedOutput, PressurizedRecipe> implements IFluidHandler, IGasHandler, ITubeConnection, ISustainedData, ITankManager
+public class TileEntityPRC extends TileEntityBasicMachine<PressurizedInput, PressurizedOutput, PressurizedRecipe> implements IFluidHandler, IGasHandler, IGasTankInfoProvider, ITubeConnection, ISustainedData, ITankManager
 {
 	public FluidTank inputFluidTank = new FluidTank(10000);
 	public GasTank inputGasTank = new GasTank(10000);
@@ -439,6 +443,13 @@ public class TileEntityPRC extends TileEntityBasicMachine<PressurizedInput, Pres
 	public boolean canDrawGas(ForgeDirection side, Gas type)
 	{
 		return configComponent.getOutput(TransmissionType.GAS, side.ordinal(), facing).hasSlot(2) && outputGasTank.canDraw(type);
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return new GasTankInfo[] {inputGasTank, outputGasTank};
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
@@ -6,11 +6,15 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.Coord4D;
 import mekanism.api.IHeatTransfer;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.IGasHandler;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.Mekanism;
@@ -42,7 +46,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
-public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock implements ISideConfiguration, ITankManager, IFluidHandler, IFrequencyHandler, IGasHandler, IHeatTransfer, ITubeConnection, IComputerIntegration, ISecurityTile
+public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock implements ISideConfiguration, ITankManager, IFluidHandler, IFrequencyHandler, IGasHandler, IGasTankInfoProvider, IHeatTransfer, ITubeConnection, IComputerIntegration, ISecurityTile
 {
 	public InventoryFrequency frequency;
 	
@@ -541,6 +545,13 @@ public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock imp
 		}
 		
 		return false;
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return hasFrequency() ? new GasTankInfo[] {frequency.storedGas} : IGasTankInfoProvider.NONE;
 	}
 	
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
@@ -5,6 +5,8 @@ import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.Coord4D;
 import mekanism.api.MekanismConfig.usage;
 import mekanism.api.Range4D;
@@ -12,8 +14,10 @@ import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.GasTransmission;
 import mekanism.api.gas.IGasHandler;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.common.Mekanism;
 import mekanism.common.Upgrade;
@@ -46,7 +50,7 @@ import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidContainerItem;
 import net.minecraftforge.fluids.IFluidHandler;
 
-public class TileEntityRotaryCondensentrator extends TileEntityElectricBlock implements IActiveState, ISustainedData, IFluidHandler, IGasHandler, ITubeConnection, IRedstoneControl, IUpgradeTile, IUpgradeInfoHandler, ITankManager, ISecurityTile
+public class TileEntityRotaryCondensentrator extends TileEntityElectricBlock implements IActiveState, ISustainedData, IFluidHandler, IGasHandler, IGasTankInfoProvider, ITubeConnection, IRedstoneControl, IUpgradeTile, IUpgradeInfoHandler, ITankManager, ISecurityTile
 {
 	public GasTank gasTank = new GasTank(MAX_FLUID);
 
@@ -463,6 +467,13 @@ public class TileEntityRotaryCondensentrator extends TileEntityElectricBlock imp
 	public boolean canReceiveGas(ForgeDirection side, Gas type)
 	{
 		return mode == 0 && side == MekanismUtils.getLeft(facing) ? gasTank.canReceive(type) : false;
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return new GasTankInfo[] {gasTank};
 	}
 	
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntitySolarNeutronActivator.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySolarNeutronActivator.java
@@ -5,14 +5,18 @@ import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.Coord4D;
 import mekanism.api.Range4D;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.GasTransmission;
 import mekanism.api.gas.IGasHandler;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.common.Mekanism;
 import mekanism.common.Upgrade;
@@ -40,7 +44,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-public class TileEntitySolarNeutronActivator extends TileEntityContainerBlock implements IRedstoneControl, IBoundingBlock, IGasHandler, ITubeConnection, IActiveState, ISustainedData, ITankManager, ISecurityTile, IUpgradeTile, IUpgradeInfoHandler
+public class TileEntitySolarNeutronActivator extends TileEntityContainerBlock implements IRedstoneControl, IBoundingBlock, IGasHandler, IGasTankInfoProvider, ITubeConnection, IActiveState, ISustainedData, ITankManager, ISecurityTile, IUpgradeTile, IUpgradeInfoHandler
 {
 	public GasTank inputTank = new GasTank(MAX_GAS);
 	public GasTank outputTank = new GasTank(MAX_GAS);
@@ -329,6 +333,13 @@ public class TileEntitySolarNeutronActivator extends TileEntityContainerBlock im
 	public boolean canDrawGas(ForgeDirection side, Gas type) 
 	{
 		return side == ForgeDirection.getOrientation(facing) && outputTank.canDraw(type);
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return new GasTankInfo[] {inputTank, outputTank};
 	}
 	
 	@Override

--- a/src/main/java/mekanism/generators/common/tile/TileEntityBioGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityBioGenerator.java
@@ -4,6 +4,8 @@ import io.netty.buffer.ByteBuf;
 
 import java.util.ArrayList;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.MekanismConfig;
 import mekanism.api.MekanismConfig.generators;
 import mekanism.api.MekanismConfig.mekce_generators;
@@ -16,7 +18,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class TileEntityBioGenerator extends TileEntityGenerator implements IGasHandler, ITubeConnection, ISustainedData
+public class TileEntityBioGenerator extends TileEntityGenerator implements IGasHandler, IGasTankInfoProvider, ITubeConnection, ISustainedData
 {
 	/** The maximum amount of gas this block can store. */
 	public int MAX_GAS = 18000;
@@ -322,6 +324,13 @@ public class TileEntityBioGenerator extends TileEntityGenerator implements IGasH
 	public boolean canDrawGas(ForgeDirection side, Gas type)
 	{
 		return false;
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return new GasTankInfo[] {fuelTank};
 	}
 
 	@Override

--- a/src/main/java/mekanism/generators/common/tile/TileEntityGasGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityGasGenerator.java
@@ -4,14 +4,18 @@ import io.netty.buffer.ByteBuf;
 
 import java.util.ArrayList;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.MekanismConfig.general;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.GasTransmission;
 import mekanism.api.gas.IGasHandler;
 import mekanism.api.gas.IGasItem;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.common.FuelHandler;
 import mekanism.common.FuelHandler.FuelGas;
@@ -22,7 +26,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class TileEntityGasGenerator extends TileEntityGenerator implements IGasHandler, ITubeConnection, ISustainedData
+public class TileEntityGasGenerator extends TileEntityGenerator implements IGasHandler, IGasTankInfoProvider, ITubeConnection, ISustainedData
 {
 	/** The maximum amount of gas this block can store. */
 	public int MAX_GAS = 18000;
@@ -349,6 +353,13 @@ public class TileEntityGasGenerator extends TileEntityGenerator implements IGasH
 	public boolean canDrawGas(ForgeDirection side, Gas type)
 	{
 		return false;
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return new GasTankInfo[] {fuelTank};
 	}
 
 	@Override

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
@@ -5,6 +5,8 @@ import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.EnumSet;
 
+import javax.annotation.Nonnull;
+
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigurable;
@@ -13,7 +15,9 @@ import mekanism.api.Range4D;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
 import mekanism.api.gas.GasStack;
+import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.IGasHandler;
+import mekanism.api.gas.IGasTankInfoProvider;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.api.reactor.IReactorBlock;
 import mekanism.common.Mekanism;
@@ -37,7 +41,7 @@ import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 import net.minecraftforge.fluids.IFluidTank;
 
-public class TileEntityReactorPort extends TileEntityReactorBlock implements IFluidHandler, IGasHandler, ITubeConnection, IHeatTransfer, IConfigurable
+public class TileEntityReactorPort extends TileEntityReactorBlock implements IFluidHandler, IGasHandler, IGasTankInfoProvider, ITubeConnection, IHeatTransfer, IConfigurable
 {
 	public boolean fluidEject;
 	
@@ -218,6 +222,13 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
 	public boolean canDrawGas(ForgeDirection side, Gas type)
 	{
 		return (type == GasRegistry.getGas("steam"));
+	}
+
+	@Override
+	@Nonnull
+	public GasTankInfo[] getTankInfo()
+	{
+		return getReactor() != null ? new GasTankInfo[] {getReactor().getDeuteriumTank(), getReactor().getTritiumTank(), getReactor().getFuelTank()} : IGasTankInfoProvider.NONE;
 	}
 
 	@Override


### PR DESCRIPTION
Resolves #163.
I chose to separate the `IGasTankInfoProvider` interface from the `IGasHandler` interface to maintain compatibility with mods which aren't supported anymore. Everything should theoretically Just Work™️ (hopefully)