### PR TITLE
Fixed incorrect block face orientation

### DIFF
--- a/src/main/java/mekanism/common/util/MekanismUtils.java
+++ b/src/main/java/mekanism/common/util/MekanismUtils.java
@@ -217,7 +217,7 @@ public final class MekanismUtils {
                 case SOUTH:
                     return EnumFacing.DOWN;
                 default:
-                    return side;
+                    return side.getOpposite();
             }
         } else if (blockFacing == EnumFacing.UP) {
             switch (side) {
@@ -230,7 +230,7 @@ public final class MekanismUtils {
                 case SOUTH:
                     return EnumFacing.UP;
                 default:
-                    return side;
+                    return side.getOpposite();
             }
         } else if (blockFacing == EnumFacing.SOUTH || side.getAxis() == Axis.Y) {
             if (side.getAxis() == Axis.Z) {


### PR DESCRIPTION
When the block is mainly facing up or down, the left and right sides are opposite
![sideconfig](https://github.com/Thorfusion/Mekanism-Community-Edition/assets/21332467/d4ff200c-d7d0-4daa-97e3-01c2449247b6)
![image](https://github.com/Thorfusion/Mekanism-Community-Edition/assets/21332467/6171b4db-c0fe-4d08-a20c-fa173fdda273)
