### PR TITLE
Fix .gitignore to include specified folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-**
+*
+!*/
+
+!.gitignore
 
 !.github/**
 !docs/**
@@ -6,7 +9,7 @@
 !gradle/**
 !libs/**
 !src/**
-!.gitignore
+
 !LICENSE.md
 !Mekanism.txt
 !README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *
 !*/
 
-!.gitignore
+!/.gitignore
 
 !.github/**
 !docs/**


### PR DESCRIPTION
In the current state, git would only commit the files excluded by gitignore, not the folders, which this PR fixes.