### PR TITLE
Fix Turbine Casing NPE

### DIFF
--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineCasing.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineCasing.java
@@ -147,7 +147,9 @@ public class TileEntityTurbineCasing extends TileEntityMultiblock<SynchronizedTu
 	@Override
 	public double getMaxEnergy() 
 	{
-		return structure.getEnergyCapacity();
+		if(structure != null)
+			return structure.getEnergyCapacity();
+		return 0.0;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes Turbine Casing causing NullPointException when structure is invalid.
`java.lang.NullPointerException: Ticking block entity
	at mekanism.generators.common.tile.turbine.TileEntityTurbineCasing.getMaxEnergy(TileEntityTurbineCasing.java:150)
	at mcjty.rftools.apideps.MekanismCompatibility.getMaxEnergyLevel(MekanismCompatibility.java:18)
	at mcjty.rftools.varia.EnergyTools.getEnergyLevelMulti(EnergyTools.java:66)
	at mcjty.rftools.blocks.monitor.RFMonitorBlockTileEntity.checkStateServer(RFMonitorBlockTileEntity.java:143)
	at mcjty.lib.entity.GenericTileEntity.func_145845_h(GenericTileEntity.java:50)`