### PR TITLE
Update Mekanism holder blocks to support Digital Miner

### DIFF
--- a/src/main/java/mekanism/common/block/BlockBasic.java
+++ b/src/main/java/mekanism/common/block/BlockBasic.java
@@ -1,5 +1,6 @@
 package mekanism.common.block;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -964,11 +965,10 @@ public class BlockBasic extends Block implements IBlockCTM, ICustomBlockIcon
 		return ret;
 	}
 
-	@Override
-	public Item getItemDropped(int i, Random random, int j)
-	{
-		return null;
-	}
+    @Override
+    public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
+        return new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
+    }
 
 	@Override
 	public boolean removedByPlayer(World world, EntityPlayer player, int x, int y, int z, boolean willHarvest)

--- a/src/main/java/mekanism/common/block/BlockCardboardBox.java
+++ b/src/main/java/mekanism/common/block/BlockCardboardBox.java
@@ -1,5 +1,7 @@
 package mekanism.common.block;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Random;
 
 import mekanism.api.MekanismConfig;
@@ -185,17 +187,10 @@ public class BlockCardboardBox extends BlockContainer
 		return world.setBlockToAir(x, y, z);
 	}
 
-	@Override
-	public int quantityDropped(Random random)
-	{
-		return 0;
-	}
-
-	@Override
-	public Item getItemDropped(int i, Random random, int j)
-	{
-		return null;
-	}
+    @Override
+    public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
+        return new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
+    }
 
 	public static class BlockData
 	{

--- a/src/main/java/mekanism/common/block/BlockEnergyCube.java
+++ b/src/main/java/mekanism/common/block/BlockEnergyCube.java
@@ -1,7 +1,8 @@
 package mekanism.common.block;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 
 import mekanism.api.energy.IEnergizedItem;
 import mekanism.common.Mekanism;
@@ -108,17 +109,10 @@ public class BlockEnergyCube extends BlockContainer
 		tileEntity.redstone = world.isBlockIndirectlyGettingPowered(x, y, z);
 	}
 
-	@Override
-	public int quantityDropped(Random random)
-	{
-		return 0;
-	}
-
-	@Override
-	public Item getItemDropped(int i, Random random, int j)
-	{
-		return null;
-	}
+    @Override
+    public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
+        return new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
+    }
 
 	@Override
 	@SideOnly(Side.CLIENT)

--- a/src/main/java/mekanism/common/block/BlockGasTank.java
+++ b/src/main/java/mekanism/common/block/BlockGasTank.java
@@ -1,7 +1,5 @@
 package mekanism.common.block;
 
-import java.util.Random;
-
 import mekanism.api.gas.IGasItem;
 import mekanism.common.Mekanism;
 import mekanism.common.MekanismBlocks;
@@ -28,6 +26,10 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import buildcraft.api.tools.IToolWrench;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -154,6 +156,11 @@ public class BlockGasTank extends BlockContainer
 		return false;
 	}
 
+    @Override
+    public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
+        return new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
+    }
+
 	@Override
 	public boolean removedByPlayer(World world, EntityPlayer player, int x, int y, int z, boolean willHarvest)
 	{
@@ -191,18 +198,6 @@ public class BlockGasTank extends BlockContainer
 		}
 
 		return itemStack;
-	}
-
-	@Override
-	public int quantityDropped(Random random)
-	{
-		return 0;
-	}
-
-	@Override
-	public Item getItemDropped(int i, Random random, int j)
-	{
-		return null;
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/block/BlockMachine.java
+++ b/src/main/java/mekanism/common/block/BlockMachine.java
@@ -738,6 +738,11 @@ public class BlockMachine extends BlockContainer implements ISpecialBounds, IBlo
 		return null;
 	}
 
+    @Override
+    public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
+        return new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
+    }
+
 	@Override
 	public boolean renderAsNormalBlock()
 	{
@@ -748,12 +753,6 @@ public class BlockMachine extends BlockContainer implements ISpecialBounds, IBlo
 	public boolean isOpaqueCube()
 	{
 		return false;
-	}
-	
-	@Override
-	public Item getItemDropped(int i, Random random, int j)
-	{
-		return null;
 	}
 
 	@Override
@@ -787,8 +786,6 @@ public class BlockMachine extends BlockContainer implements ISpecialBounds, IBlo
 	{
 		if(!player.capabilities.isCreativeMode && !world.isRemote && willHarvest)
 		{
-			TileEntityBasicBlock tileEntity = (TileEntityBasicBlock)world.getTileEntity(x, y, z);
-
 			float motion = 0.7F;
 			double motionX = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
 			double motionY = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;

--- a/src/main/java/mekanism/generators/common/block/BlockGenerator.java
+++ b/src/main/java/mekanism/generators/common/block/BlockGenerator.java
@@ -1,5 +1,6 @@
 package mekanism.generators.common.block;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -565,12 +566,6 @@ public class BlockGenerator extends BlockContainer implements ISpecialBounds, IB
 	}
 
 	@Override
-	public int quantityDropped(Random random)
-	{
-		return 0;
-	}
-
-	@Override
 	public TileEntity createTileEntity(World world, int metadata)
 	{
 		GeneratorType type = GeneratorType.getFromMetadata(metadata);
@@ -583,11 +578,16 @@ public class BlockGenerator extends BlockContainer implements ISpecialBounds, IB
 		return null;
 	}
 
-	@Override
-	public Item getItemDropped(int i, Random random, int j)
-	{
-		return null;
-	}
+    /*This method is not used, metadata manipulation is required to create a Tile Entity.*/
+    @Override
+    public TileEntity createNewTileEntity(World world, int meta) {
+        return null;
+    }
+
+    @Override
+    public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
+        return new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
+    }
 
 	@Override
 	public boolean renderAsNormalBlock()
@@ -605,13 +605,6 @@ public class BlockGenerator extends BlockContainer implements ISpecialBounds, IB
 	public int getRenderType()
 	{
 		return Mekanism.proxy.CTM_RENDER_ID;
-	}
-
-	/*This method is not used, metadata manipulation is required to create a Tile Entity.*/
-	@Override
-	public TileEntity createNewTileEntity(World world, int meta)
-	{
-		return null;
 	}
 
 	@Override


### PR DESCRIPTION
Override `getDrops` in `BlockBasic`, `BlockCardboardBox`, `BlockEnergyCube`, `BlockGasTank`, `BlockMachine`, and `BlockGenerator` to correctly handle returning the correct ItemStack for the Digital Miner when attempting to be broken. 
Closes #133