### PR TITLE
Improve Perfection Checks on getDrops()

### DIFF
--- a/src/main/java/mekanism/common/block/BlockBasic.java
+++ b/src/main/java/mekanism/common/block/BlockBasic.java
@@ -967,7 +967,7 @@ public class BlockBasic extends Block implements IBlockCTM, ICustomBlockIcon
 
     @Override
     public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
-        return new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
+        return world.isAirBlock(x, y, z) ? new ArrayList<ItemStack>() : new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
     }
 
 	@Override

--- a/src/main/java/mekanism/common/block/BlockCardboardBox.java
+++ b/src/main/java/mekanism/common/block/BlockCardboardBox.java
@@ -189,7 +189,7 @@ public class BlockCardboardBox extends BlockContainer
 
     @Override
     public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
-        return new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
+        return world.isAirBlock(x, y, z) ? new ArrayList<ItemStack>() : new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
     }
 
 	public static class BlockData

--- a/src/main/java/mekanism/common/block/BlockEnergyCube.java
+++ b/src/main/java/mekanism/common/block/BlockEnergyCube.java
@@ -111,7 +111,7 @@ public class BlockEnergyCube extends BlockContainer
 
     @Override
     public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
-        return new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
+        return world.isAirBlock(x, y, z) ? new ArrayList<ItemStack>() : new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
     }
 
 	@Override

--- a/src/main/java/mekanism/common/block/BlockGasTank.java
+++ b/src/main/java/mekanism/common/block/BlockGasTank.java
@@ -158,7 +158,7 @@ public class BlockGasTank extends BlockContainer
 
     @Override
     public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
-        return new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
+        return world.isAirBlock(x, y, z) ? new ArrayList<ItemStack>() : new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
     }
 
 	@Override

--- a/src/main/java/mekanism/common/block/BlockMachine.java
+++ b/src/main/java/mekanism/common/block/BlockMachine.java
@@ -740,7 +740,7 @@ public class BlockMachine extends BlockContainer implements ISpecialBounds, IBlo
 
     @Override
     public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
-        return new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
+        return world.isAirBlock(x, y, z) ? new ArrayList<ItemStack>() : new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
     }
 
 	@Override

--- a/src/main/java/mekanism/generators/common/block/BlockGenerator.java
+++ b/src/main/java/mekanism/generators/common/block/BlockGenerator.java
@@ -586,7 +586,7 @@ public class BlockGenerator extends BlockContainer implements ISpecialBounds, IB
 
     @Override
     public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
-        return new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
+        return world.isAirBlock(x, y, z) ? new ArrayList<ItemStack>() : new ArrayList<ItemStack>(Arrays.asList(getPickBlock(null, world, x, y, z, null)));
     }
 
 	@Override


### PR DESCRIPTION
Improved Perfection Checking on `getDrops` in BlockBasic, BlockCardboardBox, BlockEnergyCube, BlockGasTank, BlockMachine, and BlockGenerator to prevent incorrect behavior due to coordinates pointing at air when being mined.