### PR TITLE
Change jetpack check method for parity

### DIFF
--- a/src/main/java/mekanism/client/ClientTickHandler.java
+++ b/src/main/java/mekanism/client/ClientTickHandler.java
@@ -309,7 +309,7 @@ public class ClientTickHandler
 			return Mekanism.jetpackOn.contains(player.getCommandSenderName());
 		}
 
-		ItemStack stack = player.inventory.armorInventory[2];
+		ItemStack stack = player.getEquipmentInSlot(3);
 
 		if(stack != null && !player.capabilities.isCreativeMode)
 		{


### PR DESCRIPTION
Change the way the mod checks if a jetpack is equipped after `isJetpackOn` is called in `ClientTickHander` to be equivalent to the check inside `isJetpackOn` to maintain logical parity. Closes #220