### PR TITLE
Set connection timeouts for HTTP requests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,23 @@
+name: Build Test
+
+# 添加 workflow_dispatch 以实现手动触发
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      # 先尝试最基础的构建任务，确保编译能通
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,3 +33,8 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.MAVEN_TOKEN }}
           MAVEN_REPO: ${{ secrets.MAVEN_DEVREPO }}
           BUILD_VER: ${{ github.run_number }}
+      - name: Upload JAR Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Mekanism-Mod
+          path: build/libs/*.jar

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,4 +37,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Mekanism-Mod
-          path: build/libs/*.jar
+          path: output/*.jar

--- a/src/main/java/mekanism/common/util/MekanismUtils.java
+++ b/src/main/java/mekanism/common/util/MekanismUtils.java
@@ -174,6 +174,8 @@ public final class MekanismUtils
 			URL url = new URL(urlToRead);
 			HttpURLConnection conn = (HttpURLConnection)url.openConnection();
 			conn.setRequestMethod("GET");
+			conn.setConnectTimeout(500); 
+            conn.setReadTimeout(500); 
 			BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
 
 			while((line = rd.readLine()) != null)


### PR DESCRIPTION
Set connection timeouts for HTTP requests to prevent the loading process from getting stuck in regions where GitHub cannot be accessed directly.

Previously, players in certain regions would experience Forge hanging for a long time while initializing MEK-CE. I'm a beginner in coding and hope this helps; apologies if I've made any mistakes.
<img width="873" height="528" alt="搜狗截图20251205125934" src="https://github.com/user-attachments/assets/10cf865e-6455-4483-b8cf-436345d23647" />
