### PR TITLE
Set connection and read timeouts for HTTP requests

### DIFF
--- a/src/main/java/mekanism/common/util/MekanismUtils.java
+++ b/src/main/java/mekanism/common/util/MekanismUtils.java
@@ -174,6 +174,8 @@ public final class MekanismUtils
 			URL url = new URL(urlToRead);
 			HttpURLConnection conn = (HttpURLConnection)url.openConnection();
 			conn.setRequestMethod("GET");
+			conn.setConnectTimeout(800); 
+            conn.setReadTimeout(800); 
 			BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
 
 			while((line = rd.readLine()) != null)


### PR DESCRIPTION
Set connection timeouts for HTTP requests to prevent the loading process from getting stuck in regions where GitHub cannot be accessed directly.

Previously, players in certain regions would experience Forge hanging for a long time while initializing MEK-CE.
<img width="873" height="528" alt="20251205125934" src="https://github.com/user-attachments/assets/c0149682-a90f-4693-9ac4-69a3a1ee4c65" />
 I'm a beginner in coding and hope this helps; apologies if I've made any mistakes.